### PR TITLE
Add check for config and use relative paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 
 	localstore "github.com/discentem/pantri_but_go/stores/local"
 )
@@ -24,6 +25,12 @@ func main() {
 		upload   = flag.Bool("upload", false, "upload objects to pantri")
 		retrieve = flag.Bool("retrieve", false, "retrieve objects from pantri")
 	)
+	// Make sure we are in a repo with a config
+	_, err := os.Stat(".config.yaml")
+	if os.IsNotExist(err) {
+		log.Fatal("Cannot find .config.yaml, aborting...")
+	}
+
 	flag.Parse()
 	if !*upload && !*retrieve {
 		log.Fatal("one of {upload, retrieve} must be passed")

--- a/stores/local/local.go
+++ b/stores/local/local.go
@@ -82,7 +82,7 @@ func (s *Store) generateMetadata(f os.File) (*metadata.ObjectMetaData, error) {
 func (s *Store) Upload(objects []string) error {
 	for _, o := range objects {
 		// open real object in repo
-		f, err := os.Open(path.Join(s.gitRepo, o))
+		f, err := os.Open(o)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func (s *Store) Upload(objects []string) error {
 		if err := os.WriteFile(objp, b, 0644); err != nil {
 			return err
 		}
-		mf, err := os.Open(objp)
+		mf, err := os.Create(objp)
 		if err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ func (s *Store) Upload(objects []string) error {
 			return err
 		}
 		// write json to pfile
-		mpath := path.Join(s.gitRepo, fmt.Sprintf("%s.pfile", o))
+		mpath := path.Join(fmt.Sprintf("%s.pfile", o))
 		if err := os.WriteFile(mpath, blob, 0644); err != nil {
 			return err
 		}


### PR DESCRIPTION
Quick iterative change here:

- Look for `.config.yaml` and bail if it doesn't exist.  We should always run this tool from the root of the repo
- use os.Create for new files in local store as os.Open expects the file to already exist
- Use relative paths everywhere as we are now assumed to be operating out of the root of the given repo (Maybe we can be smarter about this...)