### PR TITLE
Make local file removal false by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
 						Name:  "remove",
-						Value: true,
+						Value: false,
 						Usage: "Remove the file from local sourceRepo if present",
 					},
 				},


### PR DESCRIPTION
The default behavior of deleting the file from the source repo could be confusing and also not desired by default.

For instance, if I am running this after an autopkg run, I may want the package to remain on disk for subsequent autopkg runs. 