### PR TITLE
fix s3store.getBucketName parsing and add additional test case

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -78,7 +78,7 @@ type FsysWriteRequest struct {
 	Extension string
 }
 
-// WriteMetadata generates Cavorite metadata for obj and writes it to s.Fsys
+// WriteToFsys generates Cavorite metadata for req.Object and writes it to req.Fsys
 func WriteToFsys(req FsysWriteRequest) (err error) {
 	logger.V(2).Infof("object: %s", req.Object)
 	// generate metadata

--- a/stores/s3.go
+++ b/stores/s3.go
@@ -239,7 +239,14 @@ func (s *s3Store) getBucketName() (string, error) {
 	case strings.HasPrefix(s.Options.BackendAddress, "http://"):
 		fallthrough
 	case strings.HasPrefix(s.Options.BackendAddress, "https://"):
-		_, bucketName = path.Split(s.Options.BackendAddress)
+		up, err := url.Parse(s.Options.BackendAddress)
+		if err != nil {
+			return "", err
+		}
+		p := strings.SplitN(up.Path, "/", 2)[1]
+		fragments := strings.Split(p, "/")
+		bucket := fragments[0]
+		return bucket, nil
 	default:
 		return "", fmt.Errorf("unsupported s3 backend address")
 	}


### PR DESCRIPTION
fix s3store.getBucketName parsing and add additional test case

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/discentem/cavorite/pull/137).
* __->__ #137
* #136
* #134
* #133