### PR TITLE
fix localstore plugin and add unit test to catch if all files don't need to be retrieved

### DIFF
--- a/internal/cli/retrieve.go
+++ b/internal/cli/retrieve.go
@@ -52,6 +52,10 @@ func Retrieve(ctx context.Context, fsys afero.Fs, s stores.Store, cfiles ...stri
 		}
 		cmap[cfile] = *m
 	}
+	if len(cmap) == 0 {
+		logger.Infof("retrieval not needed, all requested files are present from %v", cfiles)
+		return nil
+	}
 	retrieveErr := s.Retrieve(ctx, cmap, cfiles...)
 	return multierr.Append(result, retrieveErr).ErrorOrNil()
 

--- a/stores/BUILD.bazel
+++ b/stores/BUILD.bazel
@@ -44,12 +44,14 @@ go_test(
     srcs = [
         "azure_test.go",
         "gcs_test.go",
+        "plugin_test.go",
         "s3_test.go",
         "stores_test.go",
     ],
     embed = [":stores"],
     deps = [
         "//metadata",
+        "//stores/pluginproto:pluginproto_go_proto",
         "//testutils",
         "@com_github_aws_aws_sdk_go_v2_feature_s3_manager//:manager",
         "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",
@@ -62,5 +64,6 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//option",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/stores/plugin_test.go
+++ b/stores/plugin_test.go
@@ -1,0 +1,47 @@
+package stores
+
+import (
+	"testing"
+	"time"
+
+	"github.com/discentem/cavorite/metadata"
+	"github.com/discentem/cavorite/stores/pluginproto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestMetadataMapToPluginProtoMap(t *testing.T) {
+	expected := map[string]*pluginproto.ObjectMetadata{
+		"thing.cfile": {
+			Name:         "thing",
+			Checksum:     "whatever",
+			DateModified: timestamppb.New(time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+	actual := MetadataMapToPluginProtoMap(metadata.CfileMetadataMap{
+		"thing.cfile": metadata.ObjectMetaData{
+			Name:     "thing",
+			Checksum: "whatever",
+		},
+	})
+	require.Equal(t, expected, actual)
+}
+
+func TestPluginProtoMapToMetadataMap(t *testing.T) {
+	expected := metadata.CfileMetadataMap{
+		"thing.cfile": metadata.ObjectMetaData{
+			Name:     "thing",
+			Checksum: "whatever",
+		},
+	}
+	actual := PluginProtoMapToMetadataMap(&pluginproto.ObjectsAndMetadataMap{
+		Map: map[string]*pluginproto.ObjectMetadata{
+			"thing.cfile": {
+				Name:         "thing",
+				Checksum:     "whatever",
+				DateModified: timestamppb.New(time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			},
+		},
+	})
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
fix localstore plugin and add unit test to catch if all files don't need to be retrieved

user: BK <brandonk@uber.com>

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/discentem/cavorite/pull/141).
* __->__ #141
* #139