### PR TITLE
add exec.Stream() which streams long running commands to a io.WriteCloser, often os.Stdout

### DIFF
--- a/exec/BUILD.bazel
+++ b/exec/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
 go_test(
     name = "exec_test",
     srcs = ["exec_test.go"],
+    data = ["test/artifacts/long_running.sh"],  # make the script available to bazel
     embed = [":exec"],
     deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -27,6 +27,33 @@ func (e *RealExecutor) Command(bin string, args ...string) {
 	e.Cmd.Args = args
 }
 
+func (e *RealExecutor) Stream(posters ...io.WriteCloser) error {
+	stdout, err := e.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := e.StderrPipe()
+	if err != nil {
+		return err
+	}
+	inputPipes := []io.ReadCloser{stdout, stderr}
+
+	if err := e.Start(); err != nil {
+		return err
+	}
+	for _, pipe := range inputPipes {
+		for _, post := range posters {
+			//nolint:errcheck
+			go WriteOutput(pipe, post)
+		}
+	}
+
+	if err := e.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func WriteOutput(in io.ReadCloser, post io.WriteCloser) error {
 	r := bufio.NewScanner(in)
 	for r.Scan() {

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bytes"
 	"io"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,16 @@ type NopBufferCloser struct {
 
 func (b *NopBufferCloser) Close() error {
 	return nil
+}
+
+func TestStream(t *testing.T) {
+	e := RealExecutor{
+		Cmd: exec.Command("bash", "test/artifacts/long_running.sh"),
+	}
+	out := bytes.Buffer{}
+	err := e.Stream(&NopBufferCloser{Buffer: &out})
+	assert.NoError(t, err)
+	assert.Equal(t, "1 \n2 \n3 \n", out.String())
 }
 
 func TestWriteOutput(t *testing.T) {

--- a/exec/test/artifacts/long_running.sh
+++ b/exec/test/artifacts/long_running.sh
@@ -1,0 +1,5 @@
+for i in {1..3};
+do
+    echo "$i "
+    sleep 1
+done


### PR DESCRIPTION
add exec.Stream() which streams long running commands to a io.WriteCloser, often os.Stdout
