### PR TITLE
more tests, expander is no longer global which was dangerous due to shared state between tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,27 +15,24 @@ import (
 )
 
 type Config struct {
-	StoreType stores.StoreType `json:"store_type" mapstructure:"store_type"`
-	Options   stores.Options   `json:"options" mapstructure:"options"`
-	Validate  func() error     `json:"-"`
+	StoreType stores.StoreType             `json:"store_type" mapstructure:"store_type"`
+	Options   stores.Options               `json:"options" mapstructure:"options"`
+	Validate  func() error                 `json:"-"`
+	Expander  func(string) (string, error) `json:"-"`
 }
 
 var (
 	Cfg Config
 )
 
-type dirExpander func(string) (string, error)
-
 var (
-	// dirExpander can be overwritten for tests
-	// expander can be overwritten with fakes for tests
-	expander             dirExpander = homedir.Expand
-	ErrValidateNil                   = errors.New("cavorite config must have a Validate() function")
-	ErrValidate                      = errors.New("validate() failed")
-	ErrDirExpander                   = errors.New("dirExpander failed")
-	ErrUnsupportedStore              = errors.New("not a supported store type")
-	ErrConfigNotExist                = errors.New("config file does not exist")
-	ErrConfigDirNotExist             = errors.New("config directory does not exist")
+	ErrValidateNil       = errors.New("cavorite config must have a Validate() function")
+	ErrValidate          = errors.New("validate() failed")
+	ErrDirExpander       = errors.New("dirExpander failed")
+	ErrDirExpanderNil    = errors.New("dirExpander cannot be nil")
+	ErrUnsupportedStore  = errors.New("not a supported store type")
+	ErrConfigNotExist    = errors.New("config file does not exist")
+	ErrConfigDirNotExist = errors.New("config directory does not exist")
 )
 
 func InitalizeStoreTypeOf(
@@ -51,6 +48,7 @@ func InitalizeStoreTypeOf(
 		Validate: func() error {
 			return nil
 		},
+		Expander: homedir.Expand,
 	}
 }
 
@@ -65,7 +63,11 @@ func (c *Config) Write(fsys afero.Fs, sourceRepo string) error {
 	if err != nil {
 		return err
 	}
-	esr, err := expander(sourceRepo)
+	if c.Expander == nil {
+		return ErrDirExpanderNil
+	}
+
+	esr, err := c.Expander(sourceRepo)
 	if err != nil {
 		return fmt.Errorf(
 			"%w: %v",

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -7,21 +7,7 @@ import (
 	"github.com/discentem/cavorite/testutils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func FsysWithJsonCavoriteConfig(t *testing.T, b []byte) afero.Fs {
-	t.Helper()
-	fs := afero.NewMemMapFs()
-	err := fs.Mkdir(".cavorite", 0o777)
-	require.NoError(t, err)
-
-	f, err := fs.Create(testutils.AbsFilePath(t, ".cavorite/config"))
-	require.NoError(t, err)
-	_, err = f.Write(b)
-	require.NoError(t, err)
-	return fs
-}
 
 // TestLoadConfig creates a pantri config file in memory
 // to be read and parsed by viper
@@ -38,7 +24,7 @@ func TestLoadConfig(t *testing.T) {
 			name:      "valid config is parsed correctly",
 			parseInto: &Config{},
 			// creating an fsys with a valid cavorite config
-			fsys: FsysWithJsonCavoriteConfig(t, []byte(`{
+			fsys: testutils.FsysWithJsonCavoriteConfig(t, []byte(`{
 					"store_type": "s3",
 					"options": {
 					 "backend_address": "s3://blahaddress/bucket",
@@ -63,7 +49,7 @@ func TestLoadConfig(t *testing.T) {
 			parseInto: nil,
 			// "options" is missing the closing curly bracket below
 			// so this is expected to cause ErrViperReadConfig
-			fsys: FsysWithJsonCavoriteConfig(t, []byte(`{
+			fsys: testutils.FsysWithJsonCavoriteConfig(t, []byte(`{
 					"store_type": "s3",
 					"options": {
 					 "backend_address": "s3://blahaddress/bucket",
@@ -79,7 +65,7 @@ func TestLoadConfig(t *testing.T) {
 			parseInto: func() *Config {
 				return &Cfg
 			}(),
-			fsys: FsysWithJsonCavoriteConfig(t, []byte(`{
+			fsys: testutils.FsysWithJsonCavoriteConfig(t, []byte(`{
 					"store_type": "s3",
 					"options": {
 					 "backend_address": "s3://blahaddress/bucket",

--- a/internal/cli/BUILD.bazel
+++ b/internal/cli/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//metadata",
         "//stores",
         "//testutils",
+        "@com_github_carolynvs_aferox//:aferox",
         "@com_github_gonuts_go_shellquote//:go-shellquote",
         "@com_github_google_logger//:logger",
         "@com_github_hashicorp_go_multierror//:go-multierror",

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -15,8 +15,35 @@ import (
 	"github.com/discentem/cavorite/stores"
 )
 
-func rootOfSourceRepo() (*string, error) {
-	absPathOfConfig, err := filepath.Abs(".cavorite/config")
+type fsWithAbs interface {
+	afero.Fs
+	Abs(path string) (string, error)
+}
+
+type osFsWithAbs struct {
+	afero.Fs
+}
+
+func (o *osFsWithAbs) Abs(path string) (string, error) {
+	return filepath.Abs(path)
+}
+
+var (
+	ErrTooManyFsyses = errors.New("too many fsyses, only one is supported")
+)
+
+func rootOfSourceRepo(fsyses ...fsWithAbs) (*string, error) {
+	if len(fsyses) > 1 {
+		return nil, ErrTooManyFsyses
+	}
+	var fsys fsWithAbs
+	if fsyses != nil {
+		fsys = fsyses[0]
+	} else {
+		fsys = &osFsWithAbs{Fs: afero.NewOsFs()}
+	}
+
+	absPathOfConfig, err := fsys.Abs(".cavorite/config")
 	if err != nil {
 		return nil, errors.New(".cavorite/config not detected, not in sourceRepo root")
 	}
@@ -43,7 +70,7 @@ func removePathPrefix(objects []string, prefix string) ([]string, error) {
 func initStoreFromConfig(ctx context.Context, cfg config.Config, fsys afero.Fs) (stores.Store, error) {
 	switch cfg.StoreType {
 	case stores.StoreTypeS3:
-		s3, err := stores.NewS3StoreClient(ctx, fsys, cfg.Options)
+		s3, err := stores.NewS3Store(ctx, fsys, cfg.Options)
 		if err != nil {
 			return nil, fmt.Errorf("improper stores.S3Client init: %v", err)
 		}

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -2,15 +2,19 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/carolynvs/aferox"
 	"github.com/discentem/cavorite/config"
 	"github.com/discentem/cavorite/metadata"
 	"github.com/discentem/cavorite/stores"
+	"github.com/google/logger"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemovePathPrefix(t *testing.T) {
@@ -107,4 +111,105 @@ func TestInitStoreFromConfig_InvalidateStoreType(t *testing.T) {
 	)
 
 	assert.Errorf(t, err, "type %s is not supported", "s4")
+}
+
+type aferoxWithAbsErr struct {
+	aferox.Aferox
+}
+
+func newAferoxWithAbsErr(root string, fs *afero.Fs) *aferoxWithAbsErr {
+	return &aferoxWithAbsErr{
+		Aferox: aferox.NewAferox(root, *fs),
+	}
+}
+
+func (a *aferoxWithAbsErr) Abs(path string) (string, error) {
+	_, err := a.Afero.Open(path)
+	if err != nil {
+		return "", err
+	}
+	return a.Aferox.Abs(path), nil
+}
+
+func TestRootOfSourceRepo(t *testing.T) {
+	type test struct {
+		name        string
+		fsyses      []fsWithAbs
+		expected    func(*string) bool
+		expectedErr error
+	}
+	tests := []test{
+		{
+			name: "too many fsyses",
+			fsyses: func() []fsWithAbs {
+				memfs := afero.NewMemMapFs()
+				return []fsWithAbs{
+					newAferoxWithAbsErr("", &memfs),
+					newAferoxWithAbsErr("", &memfs),
+				}
+			}(),
+			expected: func(s *string) bool {
+				return s == nil
+			},
+			expectedErr: ErrTooManyFsyses,
+		},
+		{
+			name: "no .cavorite/config",
+			fsyses: []fsWithAbs{newAferoxWithAbsErr("", func() *afero.Fs {
+				memfs := afero.NewMemMapFs()
+				return &memfs
+			}())},
+			expectedErr: errors.New(
+				".cavorite/config not detected, not in sourceRepo root",
+			),
+			expected: func(path *string) bool {
+				return path == nil
+			},
+		},
+		{
+			name: "with .cavorite/config",
+			fsyses: func(t *testing.T) []fsWithAbs {
+				memfs := afero.NewMemMapFs()
+				err := memfs.MkdirAll("code_repo", 0755)
+				require.NoError(t, err)
+				f, err := memfs.Create("/code_repo/.cavorite/config")
+				require.NoError(t, err)
+				_, err = f.Write([]byte(`{
+					"store_type": "s3",
+					"options": {
+						"backend_address": "s3://blahaddress/bucket",
+						"metadata_file_extension": "",
+						"region": "us-east-9876"
+					}	
+				}`))
+				require.NoError(t, err)
+				return []fsWithAbs{newAferoxWithAbsErr("/code_repo", &memfs)}
+			}(t),
+			expected: func(s *string) bool {
+				return assert.Equal(t, "/code_repo", *s)
+			},
+			expectedErr: nil,
+		},
+	}
+	logger.Init("helpers_test", true, false, os.Stdout)
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var root *string
+			var err error
+			if test.fsyses == nil {
+				root, err = rootOfSourceRepo()
+			} else {
+				root, err = rootOfSourceRepo(test.fsyses...)
+			}
+			require.Equal(t, test.expectedErr, err)
+			if test.expected == nil {
+				t.Error("test.expected function must be provided")
+				t.Fail()
+			} else {
+				require.Equal(t, test.expected(root), true)
+			}
+
+		})
+	}
 }

--- a/metadata/BUILD.bazel
+++ b/metadata/BUILD.bazel
@@ -17,7 +17,9 @@ go_test(
     embed = [":metadata"],
     deps = [
         "//testutils",
+        "@com_github_google_logger//:logger",
         "@com_github_spf13_afero//:afero",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -31,6 +31,9 @@ type ObjectMetaData struct {
 type CfileMetadataMap map[string]ObjectMetaData
 
 func HashFromCfileMatches(fsys afero.Fs, cfile string, expected string) (bool, error) {
+	if fsys == nil {
+		return false, errors.New("fsys cannot be nil")
+	}
 	obj := strings.TrimSuffix(cfile, filepath.Ext(cfile))
 	f, err := fsys.Open(obj)
 	if err != nil {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,13 +1,17 @@
 package metadata
 
 import (
+	"errors"
+	"io"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/discentem/cavorite/testutils"
+	"github.com/google/logger"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseCFile(t *testing.T) {
@@ -38,7 +42,7 @@ func TestParseCFile(t *testing.T) {
 	assert.Equal(t, expect, *actual)
 }
 
-func TestWriteMetadataToFsys(t *testing.T) {
+func TestWriteToFsys(t *testing.T) {
 	mTime, _ := time.Parse("2006-01-02T15:04:05.000Z", "2014-11-12T11:45:26.371Z")
 	memfs, _ := testutils.MemMapFsWith(map[string]testutils.MapFile{
 		"thing/a/whatever": {
@@ -65,5 +69,93 @@ func TestWriteMetadataToFsys(t *testing.T) {
  "checksum": "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52",
  "date_modified": "2014-11-12T11:45:26.371Z"
 }`)
+}
 
+type fsWithBrokenOpen struct {
+	afero.Fs
+}
+
+func (f *fsWithBrokenOpen) Open(name string) (afero.File, error) {
+	return nil, errors.New("open is intentionally broken in fsWithBrokenOpen implementation")
+}
+
+func TestHashFromCfileMatches(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfile         string
+		fsys          afero.Fs
+		expectedHash  string
+		expectedMatch bool
+		errExpected   func(err error) bool
+	}{
+		{
+			name: "fsys cannot be nil",
+			fsys: nil,
+			errExpected: func(err error) bool {
+				// we expect to get an error if fsys is nil
+				return err != nil
+			},
+		},
+		{
+			name: "fsys.Open fails",
+			fsys: func(t *testing.T) afero.Fs {
+				fs, err := testutils.MemMapFsWith(map[string]testutils.MapFile{
+					"thing": {
+						Content: []byte(`blah`),
+					},
+				})
+				assert.NoError(t, err)
+				brokenOpenFs := fsWithBrokenOpen{
+					Fs: *fs,
+				}
+				return &brokenOpenFs
+
+			}(t),
+			errExpected: func(err error) bool {
+				return assert.Error(t, err)
+			},
+		},
+		{
+			name:          "hash matches",
+			cfile:         "thing.cfile",
+			expectedHash:  "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52",
+			expectedMatch: true,
+			fsys: func(t *testing.T) afero.Fs {
+				fs, err := testutils.MemMapFsWith(map[string]testutils.MapFile{
+					"thing": {
+						Content: []byte(`blah`),
+					},
+				})
+				require.NoError(t, err)
+				return *fs
+			}(t),
+		},
+		{
+			name:          "hash does not match",
+			cfile:         "thing.cfile",
+			expectedHash:  "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52",
+			expectedMatch: false,
+			fsys: func(t *testing.T) afero.Fs {
+				fs, err := testutils.MemMapFsWith(map[string]testutils.MapFile{
+					"thing": {
+						Content: []byte(`stuff`),
+					},
+				})
+				require.NoError(t, err)
+				return *fs
+			}(t),
+		},
+	}
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger.Init("metadata_test", true, false, io.Discard)
+			actual, err := HashFromCfileMatches(test.fsys, test.cfile, test.expectedHash)
+			if test.errExpected != nil {
+				assert.Equal(t, true, test.errExpected(err))
+			}
+			assert.Equal(t, test.expectedMatch, actual)
+
+		})
+	}
 }

--- a/stores/s3.go
+++ b/stores/s3.go
@@ -89,7 +89,7 @@ func getConfig(ctx context.Context, region string, address string) (*aws.Config,
 	return &cfg, nil
 }
 
-func NewS3StoreClient(ctx context.Context, fsys afero.Fs, opts Options) (*S3Store, error) {
+func NewS3Store(ctx context.Context, fsys afero.Fs, opts Options) (*S3Store, error) {
 	cfg, err := getConfig(
 		ctx,
 		opts.Region,

--- a/stores/s3_test.go
+++ b/stores/s3_test.go
@@ -285,6 +285,18 @@ func TestS3GetBucketNameWithHTTPPrefix(t *testing.T) {
 
 }
 
+func TestGetBucketNameUnsupportedPrefix(t *testing.T) {
+	store := S3Store{
+		Options: Options{
+			BackendAddress:        "blah://thing",
+			MetadataFileExtension: "cfile",
+		},
+	}
+
+	_, err := store.getBucketName()
+	assert.Error(t, err)
+}
+
 func TestRetrieveZeroCfiles(t *testing.T) {
 	s := S3Store{}
 	err := s.Retrieve(context.Background(), metadata.CfileMetadataMap{})

--- a/testutils/BUILD.bazel
+++ b/testutils/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
     ],
     importpath = "github.com/discentem/cavorite/testutils",
     visibility = ["//:__subpackages__"],
-    deps = ["@com_github_spf13_afero//:afero"],
+    deps = [
+        "@com_github_spf13_afero//:afero",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 go_test(

--- a/testutils/memfs.go
+++ b/testutils/memfs.go
@@ -6,9 +6,11 @@ import (
 	iofs "io/fs"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
 )
 
 /*
@@ -65,4 +67,17 @@ func WalkFs(fs afero.Fs, w io.Writer) error {
 		}
 		return nil
 	})
+}
+
+func FsysWithJsonCavoriteConfig(t *testing.T, b []byte) afero.Fs {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	err := fs.Mkdir(".cavorite", 0o777)
+	require.NoError(t, err)
+
+	f, err := fs.Create(AbsFilePath(t, ".cavorite/config"))
+	require.NoError(t, err)
+	_, err = f.Write(b)
+	require.NoError(t, err)
+	return fs
 }


### PR DESCRIPTION
more tests, expander is no longer global which was dangerous due to shared state between tests

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/discentem/cavorite/pull/157).
* #158
* __->__ #157